### PR TITLE
create command that publish note to medium

### DIFF
--- a/src/components/settingTab/index.ts
+++ b/src/components/settingTab/index.ts
@@ -11,7 +11,7 @@ class BlogPublisherSettingTab extends PluginSettingTab {
 
     display() {
         const {containerEl: settingContainerEl} = this
-        const defaultPlatformOptions = {"tistory": "tistory"}
+        const defaultPlatformOptions = {"tistory": "tistory", "medium": "medium"}
         settingContainerEl.empty()
         settingContainerEl.createEl("h2", {text: "Blog Publisher"})
 

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -1,3 +1,4 @@
 export default class ENV {
     static TISTORY_URL: string = "https://www.tistory.com/apis"
+    static MEDIUM_URL: string = "https://api.medium.com"
 }


### PR DESCRIPTION
### work contents
when set the platform environment value to medium and enter the publish-note command to allow you to publish current note in medium.

### complete conditions
- test for working well in obsidian test vault